### PR TITLE
C4 and accid on lamps

### DIFF
--- a/code/game/machinery/hybrisa_lights.dm
+++ b/code/game/machinery/hybrisa_lights.dm
@@ -49,6 +49,7 @@
 	icon = 'icons/obj/structures/props/64x64_hybrisarandomprops.dmi'
 	icon_state = "street_off"
 	layer = BILLBOARD_LAYER
+	unacidable = FALSE
 
 /obj/structure/machinery/colony_floodlight/street/Initialize(mapload, ...)
 	. = ..()
@@ -63,7 +64,7 @@
 		icon_state = "street_off"
 
 // Traffic
-/obj/structure/machinery/colony_floodlight/traffic
+/obj/structure/machinery/colony_floodlight/street/traffic
 	lum_value = 0
 	name = "traffic light"
 	desc = "A traffic light"
@@ -75,11 +76,11 @@
 	health = 200
 	layer = BILLBOARD_LAYER
 
-/obj/structure/machinery/colony_floodlight/traffic/Initialize(mapload, ...)
+/obj/structure/machinery/colony_floodlight/street/traffic/Initialize(mapload, ...)
 	. = ..()
 	AddComponent(/datum/component/shimmy_around, east_offset = -15, west_offset = -15)
 
-/obj/structure/machinery/colony_floodlight/traffic/update_icon()
+/obj/structure/machinery/colony_floodlight/street/traffic/update_icon()
 	if(damaged)
 		icon_state = "trafficlight_damaged"
 	else if(is_on)
@@ -87,10 +88,10 @@
 	else
 		icon_state = "trafficlight"
 
-/obj/structure/machinery/colony_floodlight/traffic/alt
+/obj/structure/machinery/colony_floodlight/street/traffic/alt
 	icon_state = "trafficlight_alt"
 
-/obj/structure/machinery/colony_floodlight/traffic/alt/update_icon()
+/obj/structure/machinery/colony_floodlight/street/traffic/alt/update_icon()
 	if(damaged)
 		icon_state = "trafficlight_alt_damaged"
 	else if(is_on)

--- a/code/game/machinery/hybrisa_lights.dm
+++ b/code/game/machinery/hybrisa_lights.dm
@@ -72,9 +72,7 @@
 	icon_state = "trafficlight"
 	bound_width = 32
 	bound_height = 32
-	density = TRUE
 	health = 200
-	layer = BILLBOARD_LAYER
 
 /obj/structure/machinery/colony_floodlight/street/traffic/Initialize(mapload, ...)
 	. = ..()

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -148,7 +148,7 @@
 	..()
 	if(AM == cause_data.resolve_mob())
 		return
-	
+
 	if(isliving(AM))
 		var/mob/living/living_mob = AM
 		if(living_mob.ally_of_hivenumber(hivenumber))
@@ -409,6 +409,12 @@
 		else
 			var/turf/turf = acid_t
 			turf.ScrapeAway()
+
+	else if(istype(acid_t, /obj/structure/machinery/colony_floodlight))
+		var/obj/structure/machinery/colony_floodlight/colony_floodlight = acid_t
+		if(!colony_floodlight.damaged)
+			colony_floodlight.set_damaged()
+
 
 	else if (istype(acid_t, /obj/structure/girder))
 		var/obj/structure/girder/girder = acid_t

--- a/code/game/objects/effects/aliens.dm
+++ b/code/game/objects/effects/aliens.dm
@@ -412,7 +412,7 @@
 
 	else if(istype(acid_t, /obj/structure/machinery/colony_floodlight))
 		var/obj/structure/machinery/colony_floodlight/colony_floodlight = acid_t
-		if(!colony_floodlight.damaged)
+		if(!colony_floodlight.damaged && colony_floodlight.is_on)
 			colony_floodlight.set_damaged()
 
 

--- a/code/game/objects/items/explosives/plastic.dm
+++ b/code/game/objects/items/explosives/plastic.dm
@@ -294,6 +294,9 @@
 	for(var/obj/structure/machinery/door/D in orange(1, target_turf))
 		D.ex_act(1000 * penetration, , cause_data)
 
+	for(var/obj/structure/machinery/colony_floodlight/street/light in range (1, target_turf))
+		light.Destroy()
+
 	handle_explosion(target_turf, dir, temp_cause)
 
 /obj/item/explosive/plastic/proc/handle_explosion(turf/target_turf, dir, cause_data)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -142,6 +142,8 @@
 		QDEL_IN(A, 20)
 		return
 
+
+
 	if(isturf(O))
 		A.icon_state += "_wall"
 

--- a/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/ability_helper_procs.dm
@@ -142,8 +142,6 @@
 		QDEL_IN(A, 20)
 		return
 
-
-
 	if(isturf(O))
 		A.icon_state += "_wall"
 

--- a/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
+++ b/maps/map_files/LV759_Hybrisa_Prospera/LV759_Hybrisa_Prospera.dmm
@@ -534,7 +534,7 @@
 /turf/open/floor/strata/orange_edge/east,
 /area/lv759/indoors/wy_research_complex/hangarbay)
 "aew" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_x = 8;
 	pixel_y = 12
@@ -1182,7 +1182,7 @@
 /turf/open/floor/corsat/officetiles,
 /area/lv759/indoors/wy_security/checkpoint_central)
 "ajX" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	pixel_x = 8;
 	pixel_y = 5
 	},
@@ -5089,7 +5089,7 @@
 /turf/open/hybrisa/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_east_street_LZ)
 "aRR" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_x = 5;
 	pixel_y = 10
@@ -5503,7 +5503,7 @@
 /turf/open/floor/prison,
 /area/lv759/indoors/landing_zone_1/flight_control_room)
 "aUQ" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	pixel_x = 4;
 	pixel_y = 12
 	},
@@ -12782,7 +12782,7 @@
 	pixel_x = -8;
 	pixel_y = 12
 	},
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 8;
 	pixel_y = 10
 	},
@@ -14777,7 +14777,7 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/bar/entertainment)
 "cvf" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 12
@@ -15128,7 +15128,7 @@
 /turf/open/floor/plating,
 /area/lv759/indoors/mining_outpost/south)
 "cxR" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 4;
 	pixel_y = 12
 	},
@@ -18977,7 +18977,7 @@
 /area/lv759/indoors/weyyu_office/vip)
 "dbp" = (
 /obj/effect/decal/cleanable/blood/oil/streak,
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 1;
 	pixel_x = 5;
 	pixel_y = 10
@@ -21421,7 +21421,7 @@
 /turf/open/auto_turf/hybrisa_auto_turf/layer0,
 /area/lv759/indoors/caves/south_east_caves)
 "dvb" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 8;
 	pixel_x = 8;
 	pixel_y = 12
@@ -24313,7 +24313,7 @@
 /turf/open/floor/hybrisa/engineership/ship_hull/non_weedable_hull,
 /area/lv759/oob)
 "dUX" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 1;
 	pixel_x = 2;
 	pixel_y = 8
@@ -27374,7 +27374,7 @@
 /turf/open/floor/hybrisa/metal/bluemetal1,
 /area/lv759/indoors/weyyu_office)
 "eui" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 4;
 	pixel_y = 8;
 	pixel_x = 5
@@ -29782,7 +29782,7 @@
 /turf/closed/wall/hybrisa/colony,
 /area/lv759/indoors/caves/east_caves)
 "ePo" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 1;
 	pixel_x = 2;
 	pixel_y = 12
@@ -32203,7 +32203,7 @@
 /area/lv759/indoors/spaceport/engineering)
 "fke" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 8;
 	pixel_x = 8;
 	pixel_y = 12
@@ -35794,7 +35794,7 @@
 /turf/open/floor/hybrisa/tile/cementflat,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_lounge_hallway)
 "fPQ" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 1;
 	pixel_x = 5;
 	pixel_y = 5;
@@ -35944,7 +35944,7 @@
 /turf/open/floor/hybrisa/carpet/carpetblack,
 /area/lv759/indoors/casino)
 "fQV" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_x = 4;
 	pixel_y = 12
@@ -38006,7 +38006,7 @@
 	icon_state = "trash_6"
 	},
 /obj/effect/hybrisa/decal/dirt_2,
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 8;
 	pixel_y = 10
 	},
@@ -50157,7 +50157,7 @@
 /obj/effect/hybrisa/decal/trash{
 	icon_state = "trash_3"
 	},
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 4;
 	pixel_y = 12
 	},
@@ -53646,7 +53646,7 @@
 /area/lv759/outdoors/colony_streets/south_east_street)
 "iMb" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	pixel_x = 8;
 	pixel_y = 4
 	},
@@ -57777,7 +57777,7 @@
 /turf/open/floor/hybrisa/carpet/carpetgreen,
 /area/lv759/indoors/apartment/eastbedrooms)
 "jwk" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 8;
 	pixel_y = 12;
 	pixel_x = 5
@@ -62703,7 +62703,7 @@
 /turf/open/floor/corsat/spiralblueoffice,
 /area/lv759/indoors/wy_research_complex/xenobiology)
 "knf" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 1;
 	pixel_x = 2;
 	pixel_y = 5
@@ -64965,7 +64965,7 @@
 /area/lv759/indoors/power_plant/equipment_west)
 "kDL" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 1;
 	pixel_x = 5;
 	pixel_y = 15
@@ -68468,7 +68468,7 @@
 /turf/open/hybrisa/street/sidewalkfull,
 /area/lv759/outdoors/colony_streets/north_street)
 "liK" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 10
@@ -78305,7 +78305,7 @@
 /turf/open/floor/prison/ramptop/east,
 /area/lv759/indoors/meridian/meridian_factory)
 "mNp" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	pixel_x = 2;
 	pixel_y = 5
 	},
@@ -80070,7 +80070,7 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "ncQ" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_y = 12
 	},
@@ -80833,7 +80833,7 @@
 /turf/open/floor/almayer/cargo,
 /area/lv759/indoors/landing_zone_2/kmcc_hub_cargo)
 "nkr" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	pixel_x = 8;
 	pixel_y = 15
 	},
@@ -81840,7 +81840,7 @@
 /area/lv759/indoors/weyyu_office)
 "nux" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 4;
 	pixel_y = 12;
 	pixel_x = 8
@@ -82487,7 +82487,7 @@
 /turf/open/floor/corsat/officetiles,
 /area/lv759/indoors/casino)
 "nAf" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	pixel_x = 5;
 	pixel_y = 5
 	},
@@ -87695,7 +87695,7 @@
 /turf/open/hybrisa/street/asphalt,
 /area/lv759/outdoors/colony_streets/north_west_street)
 "oqQ" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_x = 5;
 	pixel_y = 10
@@ -99018,7 +99018,7 @@
 /turf/open/floor/hybrisa/wood/darkerwood,
 /area/lv759/indoors/colonial_marshals/press_room)
 "qjl" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	pixel_x = 5;
 	pixel_y = 12
 	},
@@ -104094,7 +104094,7 @@
 /turf/open/floor/strata/multi_tiles,
 /area/lv759/indoors/spaceport/security)
 "rak" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 4;
 	pixel_y = 10
 	},
@@ -107869,7 +107869,7 @@
 /area/lv759/outdoors/colony_streets/central_streets)
 "rFD" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_x = 5;
 	pixel_y = 12
@@ -113885,7 +113885,7 @@
 /turf/open/floor/prison/ramptop,
 /area/lv759/indoors/meridian/meridian_foyer)
 "sBS" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	pixel_x = 2;
 	pixel_y = 5
 	},
@@ -118546,7 +118546,7 @@
 	layer = 4;
 	pixel_x = -20
 	},
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 4;
 	pixel_y = 15;
 	pixel_x = 5
@@ -119142,7 +119142,7 @@
 	},
 /area/lv759/indoors/spaceport/starglider)
 "tup" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 8;
 	pixel_y = 12;
 	pixel_x = 5
@@ -127053,7 +127053,7 @@
 /turf/open/floor/prison/darkbrown2/north,
 /area/lv759/indoors/recycling_plant/synthetic_storage)
 "uLI" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 8;
 	pixel_y = 10
 	},
@@ -130928,7 +130928,7 @@
 	pixel_x = -27;
 	pixel_y = 3
 	},
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 1;
 	pixel_x = 8;
 	pixel_y = 12
@@ -131949,7 +131949,7 @@
 /turf/open/floor/wood,
 /area/lv759/indoors/apartment/northapartments)
 "vCu" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_x = 5;
 	pixel_y = 12
@@ -133353,7 +133353,7 @@
 /area/lv759/outdoors/colony_streets/north_street)
 "vNs" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 4;
 	pixel_y = 10;
 	pixel_x = 8
@@ -134735,7 +134735,7 @@
 /turf/open/floor/almayer/black/north,
 /area/lv759/indoors/wy_research_complex/cafeteria)
 "vZe" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 4;
 	pixel_y = 12;
 	pixel_x = 6
@@ -137352,7 +137352,7 @@
 /area/lv759/indoors/meridian/meridian_foyer)
 "wvG" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	pixel_x = 5;
 	pixel_y = 15
 	},
@@ -137826,7 +137826,7 @@
 /turf/closed/wall/hybrisa/colony/engineering,
 /area/lv759/indoors/recycling_plant_office)
 "wAe" = (
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 8;
 	pixel_y = 12
 	},
@@ -147163,7 +147163,7 @@
 /turf/open/floor/hybrisa/engineership/engineer_floor1,
 /area/lv759/indoors/derelict_ship)
 "ybh" = (
-/obj/structure/machinery/colony_floodlight/traffic{
+/obj/structure/machinery/colony_floodlight/street/traffic{
 	dir = 4;
 	pixel_y = 10
 	},
@@ -148080,7 +148080,7 @@
 /area/lv759/indoors/mining_outpost/east)
 "yiH" = (
 /obj/effect/hybrisa/decal/dirt,
-/obj/structure/machinery/colony_floodlight/traffic/alt{
+/obj/structure/machinery/colony_floodlight/street/traffic/alt{
 	dir = 1;
 	pixel_x = 8;
 	pixel_y = 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

accid can be applied to damage the light and c4 to remove them compleatly, makes trafic lights subtype of streetlight as it already inherits its behavior
# Explain why it's good for the game
people asked for way to remove the lights


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->

<!-- !! If you are modifying sprites, you **must** include one or more in-game screenshots or videos of the new sprites. !! -->

<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
balance: acid can damage streetlights  and traffic lights
balance: c4 can remove streetlights and traffic lights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
